### PR TITLE
Fixed a typo where 'iMessage' was spelled 'iMassage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Now you can use this plugin to implement various types of Chat Bubbles, Audio Ch
 
 ```dart
 BubbleSpecialThree(
-  text: 'Added iMassage shape bubbles',
+  text: 'Added iMessage shape bubbles',
   color: Color(0xFF1B97F3),
   tail: false,
   textStyle: TextStyle(


### PR DESCRIPTION
I fixed the typo in the README where 'iMessage' was spelled 'iMassage'. However, the screenshot above this in the README still says 'iMassage'.