### PR TITLE
Revert visibility change on special chat bubbles

### DIFF
--- a/lib/bubbles/bubble_special_one.dart
+++ b/lib/bubbles/bubble_special_one.dart
@@ -71,7 +71,7 @@ class BubbleSpecialOne extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: CustomPaint(
-          painter: _SpecialChatBubbleOne(
+          painter: SpecialChatBubbleOne(
               color: color,
               alignment: isSender ? Alignment.topRight : Alignment.topLeft,
               tail: tail),
@@ -119,12 +119,12 @@ class BubbleSpecialOne extends StatelessWidget {
 ///
 /// [color],[alignment] and [tail] can be changed
 
-class _SpecialChatBubbleOne extends CustomPainter {
+class SpecialChatBubbleOne extends CustomPainter {
   final Color color;
   final Alignment alignment;
   final bool tail;
 
-  _SpecialChatBubbleOne({
+  SpecialChatBubbleOne({
     required this.color,
     required this.alignment,
     required this.tail,

--- a/lib/bubbles/bubble_special_three.dart
+++ b/lib/bubbles/bubble_special_three.dart
@@ -71,7 +71,7 @@ class BubbleSpecialThree extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: CustomPaint(
-          painter: _SpecialChatBubbleThree(
+          painter: SpecialChatBubbleThree(
               color: color,
               alignment: isSender ? Alignment.topRight : Alignment.topLeft,
               tail: tail),
@@ -119,12 +119,12 @@ class BubbleSpecialThree extends StatelessWidget {
 ///
 /// [color],[alignment] and [tail] can be changed
 
-class _SpecialChatBubbleThree extends CustomPainter {
+class SpecialChatBubbleThree extends CustomPainter {
   final Color color;
   final Alignment alignment;
   final bool tail;
 
-  _SpecialChatBubbleThree({
+  SpecialChatBubbleThree({
     required this.color,
     required this.alignment,
     required this.tail,

--- a/lib/bubbles/bubble_special_two.dart
+++ b/lib/bubbles/bubble_special_two.dart
@@ -71,7 +71,7 @@ class BubbleSpecialTwo extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: CustomPaint(
-          painter: _SpecialChatBubbleTwo(
+          painter: SpecialChatBubbleTwo(
               color: color,
               alignment: isSender ? Alignment.topRight : Alignment.topLeft,
               tail: tail),
@@ -119,12 +119,12 @@ class BubbleSpecialTwo extends StatelessWidget {
 ///
 /// [color],[alignment] and [tail] can be changed
 
-class _SpecialChatBubbleTwo extends CustomPainter {
+class SpecialChatBubbleTwo extends CustomPainter {
   final Color color;
   final Alignment alignment;
   final bool tail;
 
-  _SpecialChatBubbleTwo({
+  SpecialChatBubbleTwo({
     required this.color,
     required this.alignment,
     required this.tail,


### PR DESCRIPTION
In version 1.7.0 (see #56 or, more specifically, a431ae93223192069e65d0b07778dce6f97ffcb7), SpecialChatBubbles were changed from public to private. However, these components were previously public and are used in downstream applications. Making them private introduced a breaking change, which should have been released as a major version bump as per [Semantic Versioning](https://semver.org/).

This PR reverts the visibility change, making SpecialChatBubbles public again to restore backward compatibility allowing apps that used these special bubbles to also work with the latest Flutter version.