### PR TITLE
chore: add agent docs and release script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# chat_bubbles
+
+Flutter package providing chat-bubble widgets (WhatsApp-style and other shapes), a message bar, typing indicators, reactions, swipe actions, and message grouping helpers. Published on pub.dev as [`chat_bubbles`](https://pub.dev/packages/chat_bubbles).
+
+> **Note for AI agents:** this file is the source of truth. `AGENTS.md` is a symlink to it for cross-tool compatibility (Cursor, Aider, Codex, Continue, Copilot Workspace).
+
+## Common commands
+
+Always run from the **repo root**, never from `example/`.
+
+| What | Command |
+|---|---|
+| Analyze package (must be 0 issues before publish) | `dart analyze lib/` |
+| Run widget tests | `flutter test` |
+| Auto-fix lints (super-params, etc.) | `dart fix --apply lib/` |
+| Resolve deps after pubspec edits | `flutter pub get` |
+| Verify publish archive (~3 MB, 0 warnings) | `flutter pub publish --dry-run` |
+| Cut a release end-to-end | `./scripts/release.sh <X.Y.Z>` |
+| Run example app on web | `cd example && flutter run -d chrome` |
+
+## Agent ground rules
+
+- **Never `git push` to `master` directly.** Master is updated via PR from `develop` only.
+- **Never run `flutter pub publish` without explicit user approval.** A release is a one-way action.
+- **Never bump the major version without asking.** Major bumps drop users on older SDKs.
+- **Never amend or force-push commits on a shared branch.** Local-only commits may be amended freely.
+- **Always run `dart analyze lib/` before claiming a change is done.** A "0 issues" result is the bar for any code edit.
+- **When adding a public class to `lib/`, you must also add an `export` line** to `lib/chat_bubbles.dart`. Forgetting this means consumers can't reach the class — caught at v1.10.0.
+- **Use `Color.withValues(alpha: x)`, never `Color.withOpacity(x)`.** The latter is deprecated and tanks the pana score.
+- **Date format in `CHANGELOG.md` is `DD/MM/YYYY`** (e.g. `01/06/2026`). Not ISO.
+
+## Tech & constraints
+
+- **SDK:** Dart `>=3.6.0 <4.0.0`, Flutter `>=3.27.0` (required for `Color.withValues()`).
+- **Runtime dependency:** `intl: ^0.20.1` only. The package deliberately keeps zero heavy deps — anything audio/image-related is the consumer's responsibility.
+- **Lints:** `flutter_lints` + `public_member_api_docs`. `dart analyze lib/` must report **zero issues** before publishing.
+
+## Repository layout
+
+```
+.
+├── lib/                          # Published source
+│   ├── chat_bubbles.dart         # Public barrel — every consumer-facing widget is re-exported here
+│   ├── algo/                     # Date-chip text helpers
+│   ├── bubbles/                  # All bubble shapes (normal, special_{one,two,three}, audio, image, reply, link_preview)
+│   ├── date_chips/               # DateChip widget
+│   ├── groups/                   # BubbleGroupBuilder + MessageGroupHelper (consecutive-sender clustering)
+│   ├── indicators/               # TypingIndicator + TypingIndicatorWave
+│   ├── message_bars/             # MessageBar + MessageBarStyle
+│   ├── reactions/                # BubbleReaction, Reaction, ReactionPicker, ReactionOverlay
+│   ├── swipe/                    # SwipeableBubble wrapper for reply/delete gestures
+│   └── utils/                    # Internal helpers (status row, forwarded header) — NOT exported
+├── example/                      # Runnable Flutter app showing every widget. Source-only ships to pub
+├── test/                         # Widget tests
+├── images/                       # README assets + pub.dev screenshot (images/logo/logo.png)
+├── pubspec.yaml                  # Package manifest
+├── analysis_options.yaml         # Lint config
+├── .pubignore                    # Critical — excludes build/, .dart_tool/, example platform folders
+├── CHANGELOG.md                  # Required by pub.dev; one section per version (newest first)
+└── README.md                     # Renders on pub.dev landing page
+```
+
+### What gets published
+
+The `.pubignore` (NOT `.gitignore`) controls the published archive. It excludes:
+- `**/build/`, `**/.dart_tool/`, `**/pubspec.lock`, IDE files, `.DS_Store`
+- `example/android/`, `example/ios/`, `example/web/`, etc. — only `example/lib/`, `example/pubspec.yaml`, `example/README.md` ship
+
+A healthy archive is **~3 MB**. If `flutter pub publish --dry-run` reports significantly more, something is leaking in — fix `.pubignore` before publishing. Background: v1.9.0 shipped ~50 MB of leaked build artifacts and pana timed out, breaking the score page. The `.pubignore` was added in v1.9.1 to fix this.
+
+## Branching & release flow
+
+- `master` — published / stable. Tag releases here (`v1.10.0` etc.).
+- `develop` — integration branch. All feature PRs target `develop`.
+- Contributor PRs go to `master` directly when they're external (e.g. #64).
+- Release flow: bump version on `develop` → push → merge `develop` → `master` via PR → tag → publish.
+
+Commit-message convention: short subject line. Release commits are titled simply `v<version>` (e.g. `v1.10.0`).
+
+## Publishing checklist
+
+Run from the **repo root** (not from `example/` — that publishes the example app and fails with confusing errors):
+
+```bash
+# 1. Clean build artifacts so they can't leak into the archive
+cd example && flutter clean && cd ..
+rm -rf .dart_tool build
+find . -name ".DS_Store" -delete
+
+# 2. Bump pubspec.yaml + add CHANGELOG entry + update README version reference
+# 3. Verify
+dart analyze lib/                 # must be 0 issues
+flutter pub publish --dry-run     # must show ~3 MB and 0 warnings
+
+# 4. Publish
+flutter pub publish
+
+# 5. Tag from master
+git tag -a v<version> -m "v<version>"
+git push origin v<version>
+```
+
+## Version-bump touch points
+
+When cutting a release, exactly three files need the new version:
+1. `pubspec.yaml` → `version:` line
+2. `README.md` → the `chat_bubbles: ^X.Y.Z` line in the install snippet
+3. `CHANGELOG.md` → new `## [X.Y.Z] - DD/MM/YYYY` section at the top (date is DD/MM/YYYY in this project)
+
+Semver guidance for this package:
+- **Patch (x.y.Z):** bug fixes only, no public API change
+- **Minor (x.Y.0):** new widgets, new optional parameters, new exports
+- **Major (X.0.0):** removed/renamed widgets, required-parameter changes, min-SDK bumps that cut off live users
+
+## Adding a new widget
+
+1. Drop the `.dart` file under the right subfolder in `lib/` (or make a new subfolder if it's a new category).
+2. Add `export 'subfolder/your_widget.dart';` to `lib/chat_bubbles.dart`. **Forgetting this is the #1 way a feature ships but is unreachable by consumers** — caught it on v1.10.0's `MessageBarStyle`.
+3. Add a `[YourWidget]` line to the dartdoc comment block at the top of `lib/chat_bubbles.dart` under the matching category header.
+4. Add a demo section to `example/lib/main.dart`.
+5. Document parameters with `///` (the `public_member_api_docs` lint will fail otherwise).
+
+## Things that have bitten us
+
+- **Pana timeout on oversized archive** (v1.9.0) — fixed with `.pubignore` in v1.9.1.
+- **Deprecated `Color.withOpacity()`** — pana flags as 15+ analyzer infos and drops the score. Use `Color.withValues(alpha: x)` instead (Flutter 3.27+).
+- **Running publish from `example/`** — publishes the example app, fails with misleading "missing LICENSE" / "chat_bubbles in dev_dependencies" errors. Always publish from repo root.
+- **Forgetting to re-export new public classes** from `chat_bubbles.dart` — consumers can't reach them. Caught at v1.10.0 for `MessageBarStyle`.
+- **Audio playback in web demo** fails with `MEDIA_ELEMENT_ERROR` because the example pulls a sample MP3 over a URL the browser blocks. Not a package bug; ignore when web-testing the example.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# release.sh — cut a chat_bubbles release end-to-end.
+#
+# Usage:   ./scripts/release.sh <X.Y.Z>
+# Example: ./scripts/release.sh 1.10.1
+#
+# Preconditions (the script verifies and aborts if any fail):
+#   - run from repo root
+#   - working tree clean
+#   - CHANGELOG.md already has a "## [X.Y.Z] - DD/MM/YYYY" section at the top
+#   - dart analyze lib/ produces 0 issues
+#
+# Side effects on success:
+#   - updates version in pubspec.yaml and the install snippet in README.md
+#   - cleans build artifacts
+#   - runs `flutter pub publish --dry-run`
+#   - PROMPTS before running `flutter pub publish`
+#   - PROMPTS before creating + pushing the git tag
+
+set -euo pipefail
+
+red()    { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+step()   { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+
+abort() { red "ERROR: $*"; exit 1; }
+
+# --- args ---------------------------------------------------------------------
+
+[[ $# -eq 1 ]] || abort "Usage: $0 <X.Y.Z>"
+VERSION="$1"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "Version must be semver X.Y.Z (got: $VERSION)"
+
+# --- preconditions ------------------------------------------------------------
+
+step "Verifying preconditions"
+
+[[ -f pubspec.yaml && -f CHANGELOG.md && -f README.md ]] \
+  || abort "Run from repo root (pubspec.yaml not found here)."
+
+[[ -z "$(git status --porcelain)" ]] \
+  || abort "Working tree dirty. Commit or stash first."
+
+grep -q "^## \[$VERSION\] - " CHANGELOG.md \
+  || abort "CHANGELOG.md has no '## [$VERSION] - DD/MM/YYYY' entry. Add one first."
+
+# --- bump version in pubspec.yaml + README.md --------------------------------
+
+step "Bumping pubspec.yaml + README.md to $VERSION"
+
+CURRENT="$(grep '^version:' pubspec.yaml | awk '{print $2}')"
+if [[ "$CURRENT" == "$VERSION" ]]; then
+  yellow "pubspec.yaml already at $VERSION — skipping bump."
+else
+  # macOS sed needs '' after -i
+  sed -i '' "s/^version: .*/version: $VERSION/" pubspec.yaml
+  sed -i '' "s/  chat_bubbles: \^[0-9]\+\.[0-9]\+\.[0-9]\+/  chat_bubbles: ^$VERSION/" README.md
+  green "Bumped from $CURRENT → $VERSION."
+fi
+
+# --- clean build artifacts ----------------------------------------------------
+
+step "Cleaning build artifacts"
+
+(cd example && flutter clean > /dev/null) || true
+rm -rf .dart_tool build
+find . -name ".DS_Store" -delete 2>/dev/null || true
+green "Clean."
+
+# --- static analysis ----------------------------------------------------------
+
+step "Running dart analyze lib/"
+
+if ! dart analyze lib/; then
+  abort "dart analyze reported issues. Fix before releasing."
+fi
+green "Analyzer clean."
+
+# --- commit if there are bump changes ----------------------------------------
+
+if [[ -n "$(git status --porcelain pubspec.yaml README.md)" ]]; then
+  step "Committing version bump"
+  git add pubspec.yaml README.md
+  # CHANGELOG is assumed to already be committed; if it's still dirty, the
+  # earlier "working tree dirty" check would have failed.
+  git commit -m "v$VERSION"
+  green "Committed v$VERSION on $(git branch --show-current)."
+fi
+
+# --- dry-run publish ---------------------------------------------------------
+
+step "Running flutter pub publish --dry-run"
+flutter pub publish --dry-run
+
+# --- confirm + publish -------------------------------------------------------
+
+echo
+yellow "About to PUBLISH chat_bubbles $VERSION to pub.dev."
+read -r -p "Type the version to confirm: " CONFIRM
+[[ "$CONFIRM" == "$VERSION" ]] || abort "Confirmation mismatch. Aborted."
+
+step "Publishing to pub.dev"
+flutter pub publish
+
+# --- tag ---------------------------------------------------------------------
+
+echo
+read -r -p "Create + push tag v$VERSION? [y/N] " TAG_OK
+if [[ "$TAG_OK" == "y" || "$TAG_OK" == "Y" ]]; then
+  git tag -a "v$VERSION" -m "v$VERSION"
+  git push origin "v$VERSION"
+  green "Tag v$VERSION pushed."
+else
+  yellow "Skipped tagging. Remember to tag from master:  git tag -a v$VERSION -m v$VERSION && git push origin v$VERSION"
+fi
+
+green "Done. v$VERSION is live."


### PR DESCRIPTION
Add CLAUDE.md as the source of truth for AI agents working in the repo (common commands, ground rules, layout, publishing checklist). Symlink AGENTS.md to CLAUDE.md for cross-tool compatibility. Add scripts/release.sh to codify the publish flow into a single command.