### PR TITLE
v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.10.1] - 06/06/2026
+
+### Documentation
+* Added `llms.txt` (AI-agent entry point following the llmstxt.org standard) and `doc/recipes.md` (8 copy-paste recipes for common scenarios) — both ship with the package so consumer-side AI tooling can discover the API
+* Expanded `CONTRIBUTING.md` with development setup, test-suite instructions, and a PR checklist
+* Added `CLAUDE.md` / `AGENTS.md` (symlink) covering common commands, layout, and gotchas for contributors
+
+### CI / tooling
+* Added GitHub Actions workflow that runs `dart format` check, `dart analyze --fatal-infos`, `flutter test`, and `flutter pub publish --dry-run` on every push and PR to `master`/`develop`
+* Added 47 widget and unit tests covering every public widget plus `MessageGroupHelper` and `Algo.dateChipText`
+* Added `scripts/release.sh` to codify the publish flow into a single command
+* Reformatted `lib/` to match `dart format` defaults
+
 ## [1.10.0] - 31/05/2026
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,9 @@ Semver guidance for this package:
 3. Add a `[YourWidget]` line to the dartdoc comment block at the top of `lib/chat_bubbles.dart` under the matching category header.
 4. Add a demo section to `example/lib/main.dart`.
 5. Document parameters with `///` (the `public_member_api_docs` lint will fail otherwise).
-6. Add an entry to [llms.txt](llms.txt) under the matching section so AI agents using the package can discover it.
-7. If the widget has non-obvious usage, add a recipe to [doc/recipes.md](doc/recipes.md).
+6. **Add tests under `test/<subfolder>/<name>_test.dart`.** At minimum: a "renders without crashing" smoke test plus a callback assertion for every public callback param. Use the `pumpInApp(tester, widget)` helper from [test/test_utils.dart](test/test_utils.dart). CI will fail without this — `flutter test` is part of the workflow. Modifying an existing widget? Add or update tests for the new behavior.
+7. Add an entry to [llms.txt](llms.txt) under the matching section so AI agents using the package can discover it.
+8. If the widget has non-obvious usage, add a recipe to [doc/recipes.md](doc/recipes.md).
 
 ## Things that have bitten us
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,99 @@
 # Contributor Guidelines
 
-Thank you for your interest in contributing to our Flutter plugin! We welcome all contributions, whether it's filing an issue, creating a pull request, or helping other community members with their questions. To ensure a positive and productive experience for everyone, please review the following guidelines before contributing.
+Thank you for your interest in contributing to `chat_bubbles`! We welcome all contributions — filing issues, opening pull requests, or helping other community members. Please skim the sections below before contributing.
 
 ## Issues
 
-If you find a bug or have a feature request, please create an issue in the GitHub repository. Before creating an issue, please search for existing issues to avoid creating duplicates. When creating a new issue, please provide the following information:
+Before opening one, search existing issues to avoid duplicates. A useful bug report includes:
 
-- A clear and descriptive title
-- A detailed description of the issue, including any error messages or stack traces
-- Steps to reproduce the issue
+- A clear, descriptive title
+- A detailed description of the issue, including error messages or stack traces
+- Steps to reproduce
 - Expected behavior
-- Any additional information or screenshots that can help us understand the issue better
+- Screenshots if relevant
+
+## Development setup
+
+```bash
+# Required: Dart 3.6+ / Flutter 3.27+
+git clone https://github.com/prahack/chat_bubbles.git
+cd chat_bubbles
+flutter pub get
+```
+
+To run the example app:
+
+```bash
+cd example
+flutter run                  # default device
+flutter run -d chrome        # web (audio playback may fail — known)
+```
+
+## Branching
+
+- `master` — published / stable. Tagged releases live here.
+- `develop` — integration branch. **All feature PRs target `develop`.**
+
+## Running the test suite
+
+```bash
+flutter test                                              # run all tests
+dart analyze --fatal-infos --fatal-warnings lib/ test/    # static analysis
+dart format --output=none --set-exit-if-changed lib/ test/  # formatter check
+```
+
+All three must pass before opening a PR — CI enforces them.
+
+## Writing tests
+
+This is a widget package, so most tests live under `test/` and use the
+`flutter_test` framework:
+
+- **Widget tests** for anything that renders — every public widget should have at minimum a "renders without crashing" test plus a callback assertion if the widget exposes any.
+- **Pure unit tests** (`package:test`) for plain Dart helpers like `MessageGroupHelper` or `Algo`.
+
+The test folder mirrors `lib/`:
+
+```
+test/
+├── bubbles/        # BubbleNormal, BubbleSpecialOne, etc.
+├── date_chips/     # DateChip
+├── message_bars/   # MessageBar, MessageBarStyle
+├── reactions/      # BubbleReaction, ReactionPicker
+├── swipe/          # SwipeableBubble
+├── groups/         # BubbleGroupBuilder, MessageGroupHelper
+├── indicators/     # TypingIndicator
+├── algo/           # Algo, DateChipText
+└── test_utils.dart # pumpInApp(...) helper
+```
+
+**Every PR that adds a public widget or changes public behavior must include corresponding tests.** A reviewer will ask for them if they're missing. See [test/bubbles/bubble_normal_test.dart](test/bubbles/bubble_normal_test.dart) for a typical pattern.
+
+When writing widget tests, use the `pumpInApp` helper from `test/test_utils.dart` to wrap your widget in a `MaterialApp + Scaffold`.
 
 ## Pull Requests
 
-We welcome pull requests from contributors of all skill levels. Before creating a pull request, please make sure that:
+Before opening a PR:
 
-- The code follows our [coding standards](#coding-standards).
-- All tests pass locally.
-- The pull request has a clear and descriptive title.
-- The pull request includes a detailed description of the changes made.
-- The pull request includes any necessary documentation changes.
+- [ ] Code follows the [Flutter Style Guide](https://flutter.dev/docs/development/style-guide)
+- [ ] `dart format` produces no changes
+- [ ] `dart analyze --fatal-infos lib/ test/` reports zero issues
+- [ ] `flutter test` passes (all existing tests + your new ones)
+- [ ] Any new public class/parameter has dartdoc (`public_member_api_docs` lint enforces this)
+- [ ] Any new public widget is re-exported from `lib/chat_bubbles.dart`
+- [ ] `CHANGELOG.md` has an entry for your change under the next version (the maintainer can also handle this on merge)
+- [ ] The PR title is short and descriptive; the body explains the *why*
+
+PRs that touch the message bar, bubbles, or any consumer-facing widget should include a screenshot or short clip showing the before/after where it makes sense.
 
 ## Coding Standards
 
-To maintain consistency and readability, we follow the [Flutter Style Guide](https://flutter.dev/docs/development/style-guide). Please make sure that your code follows these guidelines before submitting a pull request.
+We follow the [Flutter Style Guide](https://flutter.dev/docs/development/style-guide) and the lints in [analysis_options.yaml](analysis_options.yaml) (`flutter_lints` + `public_member_api_docs`). Run `dart format` and `dart analyze` before pushing.
 
 ## License
 
 By contributing to this project, you agree that your contributions will be licensed under the [MIT License](LICENSE).
 
-## Attribution
-
-This contributor guidelines document is adapted from the [Atom Contributor Guidelines](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).
-
 ## Conclusion
 
-We value your contributions and look forward to working with you! If you have any questions, please do not hesitate to reach out to the project team or community members for help.
+We value your contributions and look forward to working with you. If anything is unclear, open an issue or ask in your PR.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  chat_bubbles: ^1.10.0
+  chat_bubbles: ^1.10.1
 ```
 
 ## Usage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: chat_bubbles
 description: Flutter chat bubble widgets, similar to Whatsapp and more shapes. Easy to use and implement
   chat bubbles.
-version: 1.10.0
+version: 1.10.1
 homepage: https://github.com/prahack/chat_bubbles
 
 environment:


### PR DESCRIPTION
## Summary

Patch release that ships the docs and CI work landed since v1.10.0. No public API changes.

### Documentation
- `llms.txt` (AI-agent entry point, llmstxt.org standard) and `doc/recipes.md` (8 copy-paste recipes) ship with the package so consumer-side AI tooling can discover the API.
- `CONTRIBUTING.md` expanded with development setup, test instructions, and a PR checklist.
- `CLAUDE.md` / `AGENTS.md` (symlink) cover common commands, layout, and gotchas for contributors. The "Adding a new widget" checklist now requires tests for any new public widget.

### CI / tooling
- GitHub Actions workflow runs `dart format` check, `dart analyze --fatal-infos`, `flutter test`, and `flutter pub publish --dry-run` on every push and PR.
- 47 widget and unit tests covering every public widget plus `MessageGroupHelper` and `Algo.dateChipText`.
- `scripts/release.sh` codifies the publish flow into one command.
- Reformatted `lib/` to match `dart format` defaults.

## Test plan
- [x] CI passes green on this PR
- [x] `flutter pub publish --dry-run` from repo root reports ~3 MB and 0 warnings
- [x] After merge: tag `v1.10.1` from master and run `flutter pub publish`